### PR TITLE
Adding API for graceful shutdown of client managers.

### DIFF
--- a/src/main/java/com/wizecommerce/hecuba/HecubaClientManager.java
+++ b/src/main/java/com/wizecommerce/hecuba/HecubaClientManager.java
@@ -796,6 +796,11 @@ public abstract class HecubaClientManager<K> {
 		return columnName + ":" + columnValue;
 	}
 
+	/**
+	 * Gracefully shuts down the cluster closing all cassandra connections.
+	 */
+	public abstract void shutDown();
+	
 	protected String getSecondaryIndexedColumnValue(String secondaryIndexKey) {
 		if (secondaryIndexKey.length() > secondaryIndexKey.indexOf(":") + 1) {
 			return secondaryIndexKey.substring(secondaryIndexKey.indexOf(":") + 1, secondaryIndexKey.length());

--- a/src/main/java/com/wizecommerce/hecuba/astyanax/AstyanaxBasedHecubaClientManager.java
+++ b/src/main/java/com/wizecommerce/hecuba/astyanax/AstyanaxBasedHecubaClientManager.java
@@ -740,4 +740,11 @@ public class AstyanaxBasedHecubaClientManager<K> extends HecubaClientManager<K> 
 		log.debug(downedHostsSB.toString());
 	}
 
+	@Override
+	public void shutDown() {
+		clusterContext.shutdown();
+		context.shutdown();
+		connectionPoolConfigurationImpl.shutdown();
+	}
+
 }

--- a/src/main/java/com/wizecommerce/hecuba/datastax/DataStaxBasedHecubaClientManager.java
+++ b/src/main/java/com/wizecommerce/hecuba/datastax/DataStaxBasedHecubaClientManager.java
@@ -1016,4 +1016,10 @@ public class DataStaxBasedHecubaClientManager<K> extends HecubaClientManager<K> 
 	@Override
 	protected void logDownedHosts() {
 	}
+	
+	@Override
+	public void shutDown() {
+		session.close();
+		cluster.close();
+	}
 }

--- a/src/main/java/com/wizecommerce/hecuba/hector/HectorBasedHecubaClientManager.java
+++ b/src/main/java/com/wizecommerce/hecuba/hector/HectorBasedHecubaClientManager.java
@@ -502,7 +502,7 @@ public class HectorBasedHecubaClientManager<K> extends HecubaClientManager<K> {
 	private CassandraResultSet<K, String> retrieveFromSecondaryIndex(String columnName, String columnValue) {
 		List<K> mappingObjectIds = retrieveKeysFromSecondaryIndex(columnName, columnValue);
 		if (CollectionUtils.isNotEmpty(mappingObjectIds)) {
-			return readAllColumns(new HashSet<K>(mappingObjectIds));
+			return readAllColumns(new LinkedHashSet<K>(mappingObjectIds));
 		}
 
 		return null;
@@ -1022,5 +1022,10 @@ public class HectorBasedHecubaClientManager<K> extends HecubaClientManager<K> {
 		}
 		downedHostsSB.append("}");
 		log.debug(downedHostsSB.toString());
+	}
+
+	@Override
+	public void shutDown() {
+		HFactory.shutdownCluster(cluster);
 	}
 }


### PR DESCRIPTION
To shutdown services using hecuba client gracefully we need to close cassandra connection managers of various implementations.
